### PR TITLE
Fixed logger writing invalid error entry

### DIFF
--- a/services/cosmosdb/CosmosDbService.cs
+++ b/services/cosmosdb/CosmosDbService.cs
@@ -15,7 +15,7 @@ public partial class CosmosDbService : ICosmosDbService
     {
         logger = loggerFactory.CreateLogger<CosmosDbService>();
 
-        logger.LogError("Initializing CosmosDbService.");
+        logger.LogInformation("Initializing CosmosDbService.");
         cosmosDbClient = new(
             connectionString: AppSettings.GetSetting("CosmosDbConnectionString"),
             clientOptions: new()


### PR DESCRIPTION
The logger was unintentionally set to use the LogError() method instead
of the LogInformation() method during initialization.